### PR TITLE
bash branch completion color fix

### DIFF
--- a/git-flow-completion.bash
+++ b/git-flow-completion.bash
@@ -209,14 +209,14 @@ __git_flow_prefix ()
 __git_flow_list_branches ()
 {
 	local prefix="$(__git_flow_prefix $1)"
-	git branch 2> /dev/null | tr -d ' |*' | grep "^$prefix" | sed s,^$prefix,, | sort
+	git branch --no-color 2> /dev/null | tr -d ' |*' | grep "^$prefix" | sed s,^$prefix,, | sort
 }
 
 __git_flow_list_remote_branches ()
 {
 	local prefix="$(__git_flow_prefix $1)"
 	local origin="$(git config gitflow.origin 2> /dev/null || echo "origin")"
-	git branch -r 2> /dev/null | sed "s/^ *//g" | grep "^$origin/$prefix" | sed s,^$origin/$prefix,, | sort
+	git branch --no-color -r 2> /dev/null | sed "s/^ *//g" | grep "^$origin/$prefix" | sed s,^$origin/$prefix,, | sort
 }
 
 # alias __git_find_on_cmdline for backwards compatibility


### PR DESCRIPTION
git branch really isn't meant to be used in scripts -- The git porcelain functions are. If you do use git branch in a script, but sure to disable color, or some systems will complete branches named 'foo' as 'foo^[[m'. Also be prepared that changes to git branch output in the future may break completion.
