### PR TITLE
Don't use color in grep

### DIFF
--- a/git-flow-completion.bash
+++ b/git-flow-completion.bash
@@ -209,14 +209,14 @@ __git_flow_prefix ()
 __git_flow_list_branches ()
 {
 	local prefix="$(__git_flow_prefix $1)"
-	git branch --no-color 2> /dev/null | tr -d ' |*' | grep "^$prefix" | sed s,^$prefix,, | sort
+	git branch --no-color 2> /dev/null | tr -d ' |*' | grep --color=never "^$prefix" | sed s,^$prefix,, | sort
 }
 
 __git_flow_list_remote_branches ()
 {
 	local prefix="$(__git_flow_prefix $1)"
 	local origin="$(git config gitflow.origin 2> /dev/null || echo "origin")"
-	git branch --no-color -r 2> /dev/null | sed "s/^ *//g" | grep "^$origin/$prefix" | sed s,^$origin/$prefix,, | sort
+	git branch --no-color -r 2> /dev/null | sed "s/^ *//g" | grep --color=never "^$origin/$prefix" | sed s,^$origin/$prefix,, | sort
 }
 
 # alias __git_find_on_cmdline for backwards compatibility


### PR DESCRIPTION
so while trying to complete the branch name, I had weird strings, i.e.:

```bash
git flow feature finish [tab] 
# => git flow feature finish ^[[01;31m^[[Kfeature/^[[m^[[K
```

which in fact are some color leftovers from grep command, adding `--color=never` fixes it