### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -9,6 +9,14 @@ The contained completion routines provide support for completing:
  * feature, hotfix and release branches
  * remote feature, hotfix and release branch names
 
+Installation with Fig
+---------------------
+
+[Fig](https://fig.io) adds apps, shortcuts, and autocomplete to your existing terminal.
+
+Install `git-flow-completion` for Bash, Zsh, or Fish with just one click.
+
+<a href="https://fig.io/plugins/other/git-flow-completion" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
 
 Installation for Bash
 ---------------------


### PR DESCRIPTION
The [Fig Plugin Store](https://fig.io/plugins) supports 1-click install for 400+ shell plugins. We have over 100k users, thousands of whom manage their shell configuration with Fig.

Git Flow Completion is already listed in the store so we'd love to have it listed as a download method on your readme. I listed it above the existing installation methods since Fig is shell-agnostic, and installation should work for zsh, bash, and fish. 

Thanks so much and please let me know if you have any concerns/questions!

